### PR TITLE
Color scheming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 bevy = "0.12.0"
 nalgebra = "0.32.3"
+rand = "0.8.5"
 rayon = "1.8.0"

--- a/src/color_gradient.rs
+++ b/src/color_gradient.rs
@@ -1,16 +1,16 @@
 use bevy::prelude::*;
 
-type Rgba = Vec4;
+type Rgba = Color;
 
 const DEFAULT_RGBA_COLORS: [Rgba; 8] = [
-  Vec4::new(0., 0., 0., 1.),
-  Vec4::new(0.016, 0.137, 0.231, 1.),
-  Vec4::new(0.145, 0.514, 0.8, 1.),
-  Vec4::new(0.886, 0.91, 0.557, 1.),
-  Vec4::new(0.82, 0.502, 0.165, 1.),
-  Vec4::new(0.839, 0.059, 0.059, 1.),
-  Vec4::new(0.549, 0.024, 0.024, 1.),
-  Vec4::new(0., 0., 0., 1.),
+  Color::rgba(0., 0., 0., 1.),
+  Color::rgba(0.016, 0.137, 0.231, 1.),
+  Color::rgba(0.145, 0.514, 0.8, 1.),
+  Color::rgba(0.886, 0.91, 0.557, 1.),
+  Color::rgba(0.82, 0.502, 0.165, 1.),
+  Color::rgba(0.839, 0.059, 0.059, 1.),
+  Color::rgba(0.549, 0.024, 0.024, 1.),
+  Color::rgba(0., 0., 0., 1.),
 ];
 
 const DEFAULT_TRESHOLDS: [f32; 8] = [0.03, 0.05, 0.08, 0.1, 0.13, 0.18, 0.25, 1.];

--- a/src/color_gradient.rs
+++ b/src/color_gradient.rs
@@ -1,0 +1,56 @@
+use bevy::prelude::*;
+
+type Rgba = UVec4;
+
+const DEFAULT_RGBA_COLORS: [Rgba; 8] = [
+  UVec4::new(0, 0, 0, 255),
+  UVec4::new(4, 35, 59, 255),
+  UVec4::new(37, 131, 204, 255),
+  UVec4::new(226, 232, 142, 255),
+  UVec4::new(209, 128, 42, 255),
+  UVec4::new(214, 15, 15, 255),
+  UVec4::new(140, 6, 6, 255),
+  UVec4::new(0, 0, 0, 255),
+];
+
+const DEFAULT_TRESHOLDS: [f32; 8] = [0.03, 0.05, 0.08, 0.1, 0.13, 0.18, 0.25, 1.];
+
+#[derive(Resource)]
+pub struct ColorGradient<const N: usize>
+{
+  colors:    [Rgba; N],
+  tresholds: [f32; N],
+}
+
+pub const DEFAULT_COLOR_GRADIENT: ColorGradient<8> = ColorGradient {
+  colors:    DEFAULT_RGBA_COLORS,
+  tresholds: DEFAULT_TRESHOLDS,
+};
+
+impl Default for ColorGradient<8>
+{
+  fn default() -> Self { DEFAULT_COLOR_GRADIENT }
+}
+
+impl<const N: usize> ColorGradient<N>
+{
+  #[inline]
+  pub fn new(colors: [Rgba; N], tresholds: [f32; N]) -> Self { Self { colors, tresholds } }
+
+  #[inline]
+  pub fn get_color(&self, x: f32) -> Rgba
+  {
+    if x <= self.tresholds[0] {
+      return self.colors[0];
+    }
+    for i in 0..N {
+      if self.tresholds[i] > x {
+        let nx = (self.tresholds[i] - x) / (self.tresholds[i] - self.tresholds[i - 1]);
+        let float_color = self.colors[i].as_vec4() * (1.0 - nx) + self.colors[i - 1].as_vec4() * nx;
+        let color = float_color.as_uvec4();
+        return color;
+      }
+    }
+    *self.colors.last().unwrap()
+  }
+}

--- a/src/color_gradient.rs
+++ b/src/color_gradient.rs
@@ -1,16 +1,16 @@
 use bevy::prelude::*;
 
-type Rgba = UVec4;
+type Rgba = Vec4;
 
 const DEFAULT_RGBA_COLORS: [Rgba; 8] = [
-  UVec4::new(0, 0, 0, 255),
-  UVec4::new(4, 35, 59, 255),
-  UVec4::new(37, 131, 204, 255),
-  UVec4::new(226, 232, 142, 255),
-  UVec4::new(209, 128, 42, 255),
-  UVec4::new(214, 15, 15, 255),
-  UVec4::new(140, 6, 6, 255),
-  UVec4::new(0, 0, 0, 255),
+  Vec4::new(0., 0., 0., 1.),
+  Vec4::new(0.016, 0.137, 0.231, 1.),
+  Vec4::new(0.145, 0.514, 0.8, 1.),
+  Vec4::new(0.886, 0.91, 0.557, 1.),
+  Vec4::new(0.82, 0.502, 0.165, 1.),
+  Vec4::new(0.839, 0.059, 0.059, 1.),
+  Vec4::new(0.549, 0.024, 0.024, 1.),
+  Vec4::new(0., 0., 0., 1.),
 ];
 
 const DEFAULT_TRESHOLDS: [f32; 8] = [0.03, 0.05, 0.08, 0.1, 0.13, 0.18, 0.25, 1.];
@@ -46,8 +46,7 @@ impl<const N: usize> ColorGradient<N>
     for i in 0..N {
       if self.tresholds[i] > x {
         let nx = (self.tresholds[i] - x) / (self.tresholds[i] - self.tresholds[i - 1]);
-        let float_color = self.colors[i].as_vec4() * (1.0 - nx) + self.colors[i - 1].as_vec4() * nx;
-        let color = float_color.as_uvec4();
+        let color = self.colors[i] * (1.0 - nx) + self.colors[i - 1] * nx;
         return color;
       }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,79 +1,73 @@
-use bevy::prelude::*;
-use bevy::render::color::Color;
-use bevy::text::TextStyle;
-use bevy::ui::{node_bundles::{ButtonBundle, NodeBundle, TextBundle}, Style, Interaction};
-use bevy::ecs::system::Resource;
-use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
-use bevy::window::Window;
+use bevy::{
+  prelude::*,
+  render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+};
 use nalgebra::{Complex, Normed};
+use rand::random;
 use rayon::prelude::*;
 
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-        .add_systems(Startup, (setup, setup_ui))
-        .add_systems(Update, (update_fractal, button_interaction_system, click_to_center))
-        .insert_resource(FractalZoom { 
-            scale: 3.0,
-            center: (-0.8, 0.156),
-        })
-        .run();
-}
+mod color_gradient;
+#[allow(non_camel_case_types)]
+type float = f32; // change to either f32 or f64
 
+fn main()
+{
+  App::new()
+    .add_plugins(DefaultPlugins)
+    .add_systems(Startup, (setup, setup_ui))
+    .add_systems(PostStartup, update_fractal)
+    .add_systems(Update, (/* update_fractal, */ button_interaction_system, click_to_center))
+    .insert_resource(FractalZoom {
+      scale:  3.0,
+      center: (-0.8, 0.156),
+    })
+    .run();
+}
 
 #[derive(Component)]
 struct FractalMaterial;
 
-fn setup(
-    mut commands: Commands,
-    mut texture_atlases: ResMut<Assets<TextureAtlas>>,
-    mut images: ResMut<Assets<Image>>,
-) {
-    let size = Vec2::new(1280.0, 1280.0);
-    let extent = Extent3d {
-        width: size.x as u32,
-        height: size.y as u32,
-        depth_or_array_layers: 1,
-    };
-    let image = Image::new_fill(
-        extent,
-        TextureDimension::D2,
-        &[0, 0, 0, 0],
-        TextureFormat::Rgba8Unorm
-    );
+fn setup(mut commands: Commands, mut texture_atlases: ResMut<Assets<TextureAtlas>>, mut images: ResMut<Assets<Image>>)
+{
+  let size = Vec2::new(1280.0, 1280.0);
+  let extent = Extent3d {
+    width:                 size.x as u32,
+    height:                size.y as u32,
+    depth_or_array_layers: 1,
+  };
+  let image = Image::new_fill(extent, TextureDimension::D2, &[0, 0, 0, 0], TextureFormat::Rgba8Unorm);
 
-    // Add image and check that it is successfully loaded
-    let image_handle = images.add(image);
-    if image_handle.is_none() {
-        eprintln!("Failed to load the image asset.");
-        return;
-    }
+  // Add image and check that it is successfully loaded
+  let image_handle = images.add(image);
+  // if image_handle.is_none() {
+  //   eprintln!("Failed to load the image asset.");
+  //   return;
+  // }
 
-    let texture_atlas = TextureAtlas::from_grid(image_handle.clone(), size, 1, 1, None, None);
-    let atlas_handle = texture_atlases.add(texture_atlas);
+  let texture_atlas = TextureAtlas::from_grid(image_handle.clone(), size, 1, 1, None, None);
+  let atlas_handle = texture_atlases.add(texture_atlas);
 
-    // Camera
-    commands.spawn(Camera2dBundle::default());
+  // Camera
+  commands.spawn(Camera2dBundle::default());
 
-    // Create a sprite to render the fractal texture atlas
-    commands.spawn((
-        SpriteSheetBundle {
-            texture_atlas: atlas_handle,
-            ..Default::default()
-        },
-        FractalMaterial,
-    ));
+  // Create a sprite to render the fractal texture atlas
+  commands.spawn((
+    SpriteSheetBundle {
+      texture_atlas: atlas_handle,
+      ..Default::default()
+    },
+    FractalMaterial,
+  ));
+  let fractal_texture = FractalTexture(image_handle);
+  let fractal_zoom = FractalZoom {
+    scale:  3.0,
+    center: (0.0, 0.0),
+  };
+  commands.insert_resource(fractal_texture);
 
-    commands.insert_resource(FractalTexture(image_handle));
-
-    // Initialize it
-    commands.insert_resource(FractalZoom { 
-        scale: 3.0, // Initial scale
-        center: (0.0, 0.0), // Initial center
-    });
-
+  // Initialize it
+  commands.insert_resource(fractal_zoom);
 }
-
 
 #[derive(Component)]
 struct ZoomInButton;
@@ -81,190 +75,205 @@ struct ZoomInButton;
 #[derive(Component)]
 struct ZoomOutButton;
 
-fn setup_ui(
-    mut commands: Commands,
-) {
-
-    commands
+fn setup_ui(mut commands: Commands)
+{
+  commands
     .spawn(NodeBundle {
-        style: Style {
-            ..Default::default()
-        },
-        background_color: Color::NONE.into(), 
-        ..Default::default()
+      style: Style { ..Default::default() },
+      background_color: Color::NONE.into(),
+      ..Default::default()
     })
     .with_children(|parent| {
-        parent.spawn(ButtonBundle {
-            style: Style {
-               ..default()
-            },
-            background_color: Color::rgb(0.15, 0.15, 0.15).into(),
-            ..Default::default()
+      parent
+        .spawn(ButtonBundle {
+          style: Style { ..default() },
+          background_color: Color::rgb(0.15, 0.15, 0.15).into(),
+          ..Default::default()
         })
         .insert(ZoomInButton)
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                "+",
-                TextStyle {
-                    font_size: 40.0,
-                    color: Color::WHITE,
-                    ..default()
-                },
-            ));
+          parent.spawn(TextBundle::from_section(
+            "+",
+            TextStyle {
+              font_size: 40.0,
+              color: Color::WHITE,
+              ..default()
+            },
+          ));
         });
     })
     .with_children(|parent| {
-        parent.spawn(ButtonBundle {
-            style: Style {
-               ..default()
-            },
-            background_color: Color::rgb(0.15, 0.15, 0.15).into(),
-            ..Default::default()
+      parent
+        .spawn(ButtonBundle {
+          style: Style { ..default() },
+          background_color: Color::rgb(0.15, 0.15, 0.15).into(),
+          ..Default::default()
         })
         .insert(ZoomOutButton)
         .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                "-",
-                TextStyle {
-                    font_size: 40.0,
-                    color: Color::WHITE,
-                    ..default()
-                },
-            ));
+          parent.spawn(TextBundle::from_section(
+            "-",
+            TextStyle {
+              font_size: 40.0,
+              color: Color::WHITE,
+              ..default()
+            },
+          ));
         });
     });
-
 }
 
-
+#[allow(clippy::type_complexity)]
 fn button_interaction_system(
-    mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor, &Children, Option<&ZoomInButton>, Option<&ZoomOutButton>),
-        (Changed<Interaction>, With<Button>),
-    >,
-    mut fractal_zoom: ResMut<FractalZoom>,
-) {
-    for (interaction, mut background_color, _, zoom_in, zoom_out) in interaction_query.iter_mut() {
-
-        match *interaction {
-            Interaction::Pressed => {
-                if zoom_in.is_some() {
-                    fractal_zoom.scale *= 0.9; // Zoom in
-                } else if zoom_out.is_some() {
-                    fractal_zoom.scale *= 1.1; // Zoom out
-                } ;
-                *background_color = BackgroundColor(Color::rgb(0.35, 0.75, 0.35));
-            }
-            _ => {
-                *background_color = BackgroundColor(Color::rgb(0.15, 0.15, 0.15));
-            }
-        }
+  mut interaction_query: Query<
+    (
+      &Interaction,
+      &mut BackgroundColor,
+      &Children,
+      Option<&ZoomInButton>,
+      Option<&ZoomOutButton>,
+    ),
+    (Changed<Interaction>, With<Button>),
+  >,
+  mut fractal_zoom: ResMut<FractalZoom>,
+  images: ResMut<Assets<Image>>,
+  fractal_texture: Res<FractalTexture>,
+)
+{
+  if let Some((interaction, mut background_color, _, zoom_in, zoom_out)) = interaction_query.iter_mut().next() {
+    match *interaction {
+      Interaction::Pressed => {
+        if zoom_in.is_some() {
+          fractal_zoom.scale *= 0.9; // Zoom in
+        } else if zoom_out.is_some() {
+          fractal_zoom.scale *= 1.1; // Zoom out
+        };
+        *background_color = BackgroundColor(Color::rgb(0.35, 0.75, 0.35));
+        update_fractal(images, fractal_texture, fractal_zoom);
+      },
+      _ => {
+        *background_color = BackgroundColor(Color::rgb(0.15, 0.15, 0.15));
+      },
     }
+  }
 }
 
 fn click_to_center(
-    mut fractal_zoom: ResMut<FractalZoom>,
-    mut windows: Query<&Window>,
-    mouse_click: Res<Input<MouseButton>>,
-) {
-    if let Some(window) = windows.iter().next() {
-        if mouse_click.just_pressed(MouseButton::Left) {
-            if let Some(cursor_position) = window.cursor_position() {
-                // Convert cursor position to fractal coordinates
-                let size = Vec2::new(window.width() as f32, window.height() as f32);
-                let fractal_x = (cursor_position.x as f64 - (size.x as f64) / 2.0) * fractal_zoom.scale / (size.x as f64) + fractal_zoom.center.0;
-                let fractal_y = (cursor_position.y as f64 - (size.y as f64) / 2.0) * fractal_zoom.scale / (size.y as f64) + fractal_zoom.center.1;
+  mut fractal_zoom: ResMut<FractalZoom>,
+  windows: Query<&Window>,
+  mouse_click: Res<Input<MouseButton>>,
+  images: ResMut<Assets<Image>>,
+  fractal_texture: Res<FractalTexture>,
+)
+{
+  if let Some(window) = windows.iter().next() {
+    if mouse_click.just_pressed(MouseButton::Left) {
+      if let Some(cursor_position) = window.cursor_position() {
+        // Convert cursor position to fractal coordinates
+        let size = Vec2::new(window.width(), window.height());
+        let fractal_x = (cursor_position.x as float - (size.x as float) / 2.0) * fractal_zoom.scale / (size.x as float) + fractal_zoom.center.0;
+        let fractal_y = (cursor_position.y as float - (size.y as float) / 2.0) * fractal_zoom.scale / (size.y as float) + fractal_zoom.center.1;
 
-                // Update fractal center
-                fractal_zoom.center = (fractal_x, fractal_y);
-            }
-        }
+        // Update fractal center
+        fractal_zoom.center = (fractal_x, fractal_y);
+        update_fractal(images, fractal_texture, fractal_zoom);
+      }
     }
+  }
 }
-
-
-
-
-
 
 #[derive(Resource)]
 struct FractalTexture(Handle<Image>);
 
 #[derive(Resource)]
-struct FractalZoom {
-    scale: f64,
-    center: (f64, f64), 
+struct FractalZoom
+{
+  scale:  float,
+  center: (float, float),
 }
 
-fn update_fractal(
-    mut images: ResMut<Assets<Image>>,
-    fractal_texture: Res<FractalTexture>,
-    fractal_zoom: Res<FractalZoom>,
-) {
-    if let Some(image) = images.get_mut(&fractal_texture.0) {
-        let size = image.texture_descriptor.size;
-        let width = size.width as usize;
-        let height = size.height as usize;
+const SUBSTEPS: u32 = 8;
 
+fn update_fractal(mut images: ResMut<Assets<Image>>, fractal_texture: Res<FractalTexture>, fractal_zoom: ResMut<FractalZoom>)
+{
+  if let Some(image) = images.get_mut(&fractal_texture.0) {
+    let size = image.texture_descriptor.size;
+    let width = size.width as usize;
+    let height = size.height as usize;
 
+    let scale = fractal_zoom.scale;
+    let center_x = fractal_zoom.center.0;
+    let center_y = fractal_zoom.center.1;
 
-        let scale = fractal_zoom.scale;
-        let center_x = fractal_zoom.center.0;
-        let center_y = fractal_zoom.center.1;
+    // Process in chunks using rayon in parallel!
+    image.data.par_chunks_mut(width * 4).enumerate().for_each(|(y, row)| {
+      for x in 0..width {
+        // Map pixel to fractal coordinate space
+        let cx = (x as float * scale / width as float) + center_x - scale / 2.0;
+        let cy = (y as float * scale / height as float) + center_y - scale / 2.0;
+        let c = Complex::new(-0.8, 0.156);
+        let mut total_color = UVec4::ZERO;
+        for _ in 0..SUBSTEPS {
+          let value = julia(
+            c,
+            cx + (random::<float>() - 0.5) / width as float,
+            cy + (random::<float>() - 0.5) / height as float,
+          );
+          let color = color_gradient::DEFAULT_COLOR_GRADIENT.get_color(value);
+          total_color += color;
+        }
+        let color = (total_color / SUBSTEPS).to_array();
 
-        // Process in chunks using rayon in parallel!
-        image.data.par_chunks_mut(width * 4).enumerate().for_each(|(y, row)| {
-            for x in 0..width {
-                // Map pixel to fractal coordinate space
-                let cx = (x as f64 * scale / width as f64) + center_x - scale / 2.0;
-                let cy = (y as f64 * scale / height as f64) + center_y - scale / 2.0;
-                let c = Complex::new(-0.8, 0.156);
+        // let value = julia(c, cx, cy);
 
-                let value = julia(c, cx, cy);
+        // Convert the fractal value to a color (RGBA)
+        // let color =
+        // color_gradient::DEFAULT_COLOR_GRADIENT.get_color(value).to_array();
 
-                // Convert the fractal value to a color (RGBA)
-                let color = map_value_to_color(value);
-
-                // Update image data
-                let offset = x * 4;
-                row[offset] = color.0;
-                row[offset + 1] = color.1;
-                row[offset + 2] = color.2;
-                row[offset + 3] = color.3;
-            }
-        });
-    }
+        // Update image data
+        let offset = x * 4;
+        (0..4).for_each(|i| row[offset + i] = color[i] as u8);
+      }
+    });
+  }
 }
-
 
 // Function to map fractal value to RGBA color
-fn map_value_to_color(value: u16) -> (u8, u8, u8, u8) {
-    let outter = u16::MAX as f64;
-    if value == u16::MAX {
-        (255, 255, 255, 255) // White for points inside the Julia set
-    } else if value < (outter * 0.0005) as u16 {
-        (0, 0, 0, 255) // Black for points outside the Julia set
-    } else {
-        let v = value as u16;
-        let (r, g, b) = (
-            ((v * 6) % 256) as u8, // Red 
-            ((v * 10) % 256) as u8, // Green 
-            ((v * 4) % 256) as u8, // Blue 
-        );
-        (r, g, b, 255) 
-    }
+// fn map_value_to_color(value: float) -> (u8, u8, u8, u8)
+// {
+//   let outter = u16::MAX as float;
+//   if value == u16::MAX {
+//     (255, 255, 255, 255) // White for points inside the Julia set
+//   } else if value < (outter * 0.0005) as u16 {
+//     (0, 0, 0, 255) // Black for points outside the Julia set
+//   } else {
+//     let v = value;
+//     let (r, g, b) = (
+//       ((v * 6) % 256) as u8,  // Red
+//       ((v * 10) % 256) as u8, // Green
+//       ((v * 4) % 256) as u8,  // Blue
+//     );
+//     (r, g, b, 255)
+//   }
+// }
+
+// Transforms the [0, 1] value to another value using a smoothstep-like function
+#[inline]
+fn smoother(iter: u8, z: Complex<float>) -> float
+{
+  (iter as float - z.norm_squared().log2().max(1.).log2()).max(0.).min(u8::MAX as float) / u8::MAX as float
 }
 
+// Returns a float between 0 and 1 that represents the color of the pixel
+fn julia(c: Complex<float>, x: float, y: float) -> float
+{
+  let mut z = Complex::new(x, y);
 
-
-fn julia(c: Complex<f64>, x: f64, y: f64) -> u16 {
-    let mut z = Complex::new(x,y);
-
-    for i in 0..255 {
-        if z.norm() > 2.0 {
-            return i as u16;
-        }
-        z = z * z + c;
+  for i in 0..u8::MAX {
+    if z.norm_squared() > 4.0 {
+      return smoother(i, z);
     }
-    u16::MAX
+    z = z * z + c;
+  }
+  smoother(u8::MAX, z)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,7 +232,7 @@ fn update_fractal(
           let cx = (x as f32 * scale / width as f32) + center_x - scale / 2.0;
           let cy = (y as f32 * scale / height as f32) + center_y - scale / 2.0;
           let c = Complex::new(-0.8, 0.156);
-          let mut total_color = Vec4::ZERO;
+          let mut total_color = Color::rgba(0., 0., 0., 0.);
           // Compute the mean color from mutiple points chosen randomly in the pixel
           for _ in 0..SUBSTEPS as i32 {
             let value = julia(
@@ -242,11 +242,12 @@ fn update_fractal(
             );
             total_color += color_gradient::DEFAULT_COLOR_GRADIENT.get_color(value);
           }
-          let color = (total_color * 255. / SUBSTEPS).round();
+          let total_color_array = total_color.as_rgba_f32();
 
           // Update image data
           let offset = x * 4;
-          (0..4).for_each(|i| row[offset + i] = color[i] as u8);
+          (0..4)
+            .for_each(|i| row[offset + i] = (total_color_array[i] / SUBSTEPS * 255.).round() as u8);
         }
       });
   }

--- a/tim-clicks-julia-example/src/main.rs
+++ b/tim-clicks-julia-example/src/main.rs
@@ -1,53 +1,51 @@
 use image::{ImageBuffer, Rgb};
 use nalgebra::{Complex, Normed};
 
-fn julia(c: Complex<f64>, x: f64, y: f64) -> u8{
-    let mut z = Complex::new(x,y);
+fn julia(c: Complex<f64>, x: f64, y: f64) -> u8
+{
+  let mut z = Complex::new(x, y);
 
-    for i in 0..255 {
-        if z.norm() > 2.0 {
-            return i as u8;
-        }
-        z = z * z + c;
+  for i in 0..255 {
+    if z.norm() > 2.0 {
+      return i as u8;
     }
-    255
+    z = z * z + c;
+  }
+  255
 }
 
-fn julia_as_u16(c: Complex<f64>, x: f64, y: f64) -> u16 {
-    let mut z = Complex::new(x,y);
+fn julia_as_u16(c: Complex<f64>, x: f64, y: f64) -> u16
+{
+  let mut z = Complex::new(x, y);
 
-    for i in 0..255 {
-        if z.norm() > 2.0 {
-            return i as u16;
-        }
-        z = z * z + c;
+  for i in 0..255 {
+    if z.norm() > 2.0 {
+      return i as u16;
     }
-    u16::MAX
+    z = z * z + c;
+  }
+  u16::MAX
 }
 
-fn main() {
-    let width = 1280;
-    let height = 1280;
+fn main()
+{
+  let width = 1280;
+  let height = 1280;
 
+  let mut img = ImageBuffer::new(width, height);
 
+  for (x, y, pixel) in img.enumerate_pixels_mut() {
+    let scale_x = 3.0 / width as f64;
+    let scale_y = 3.0 / height as f64;
 
-    let mut img = ImageBuffer::new(width, height);
+    let cx = x as f64 * scale_x - 1.5;
+    let cy = y as f64 * scale_y - 1.5;
 
-    for (x,y,pixel) in img.enumerate_pixels_mut() {
-        let scale_x = 3.0 / width as f64;
-        let scale_y = 3.0 / height as f64;
+    let c = Complex::new(-0.8, 0.156);
+    let value = julia_as_u16(c, cx, cy);
 
+    *pixel = Rgb([value, value, value]);
+  }
 
-        let cx = x as f64 * scale_x - 1.5;
-        let cy = y as f64 * scale_y - 1.5;
-
-        let c = Complex::new(-0.8, 0.156);
-        let value = julia_as_u16(c, cx, cy);
-
-        *pixel = Rgb([value,value,value]);
-
-    }
-
-    let _ = img.save("julia.png");
-
+  let _ = img.save("julia.png");
 }


### PR DESCRIPTION
This should solve issues #2 and #3. I also:

* replaced every use of `f64` by `f32` as single precision seems more common in computer graphics (`bevy` uses these in its `Color` type).
* formatted the code with a personal config of `rustfmt`. Maybe a `rustfmt.toml` should be assigned to this project so that the format is uniform among contributors (see #10).
* started to implement a anti-aliasing rendering by adding substeps for each pixel color computation. This leads of course to a worse performance, so the number of substeps is currently set to 1, and could be raised for tests or once the rendering is made by the gpu.